### PR TITLE
Add login support

### DIFF
--- a/socialapp/templates/registration/logged_out.html
+++ b/socialapp/templates/registration/logged_out.html
@@ -1,0 +1,6 @@
+{% extends 'socialapp/base.html' %}
+
+{% block content %}
+<p>You have been logged out.</p>
+<a href="{% url 'login' %}">Login again</a>
+{% endblock %}

--- a/socialapp/templates/registration/login.html
+++ b/socialapp/templates/registration/login.html
@@ -1,0 +1,10 @@
+{% extends 'socialapp/base.html' %}
+
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Login</button>
+</form>
+{% endblock %}

--- a/socialapp/templates/socialapp/base.html
+++ b/socialapp/templates/socialapp/base.html
@@ -6,9 +6,12 @@
 <body>
     <h1>Social Site</h1>
     {% if user.is_authenticated %}
-        <p>Logged in as {{ user.username }} | <a href="/admin/logout/">Logout</a></p>
+        <p>
+            Logged in as {{ user.username }} |
+            <a href="{% url 'logout' %}">Logout</a>
+        </p>
     {% else %}
-        <p><a href="/admin/login/">Login</a></p>
+        <p><a href="{% url 'login' %}">Login</a></p>
     {% endif %}
     <hr>
     {% block content %}{% endblock %}

--- a/socialsite/settings.py
+++ b/socialsite/settings.py
@@ -63,3 +63,6 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+LOGIN_REDIRECT_URL = 'home'
+LOGOUT_REDIRECT_URL = 'login'

--- a/socialsite/urls.py
+++ b/socialsite/urls.py
@@ -4,4 +4,5 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('socialapp.urls')),
+    path('accounts/', include('django.contrib.auth.urls')),
 ]


### PR DESCRIPTION
## Summary
- include Django auth routes
- create login/logout templates
- wire templates to built-in auth URLs
- redirect users after login/logout

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68406d83b4308320ba723e09a06b516a