### PR TITLE
Improve login page style

### DIFF
--- a/socialapp/templates/registration/login.html
+++ b/socialapp/templates/registration/login.html
@@ -1,8 +1,28 @@
 {% extends 'socialapp/base.html' %}
 
+{% block extra_head %}
+<style>
+    body {
+        background: linear-gradient(#004080, #002050);
+        font-family: "Trebuchet MS", Arial, sans-serif;
+        color: #fff;
+        min-height: 100vh;
+    }
+
+    .myspace-login-box {
+        background: #fff;
+        color: #000;
+        padding: 20px;
+        border-radius: 10px;
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+        margin-top: 60px;
+    }
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="row justify-content-center">
-  <div class="col-md-4">
+  <div class="col-md-4 myspace-login-box">
     <h2 class="mb-3">Login</h2>
     <form method="post">
       {% csrf_token %}

--- a/socialapp/templates/socialapp/base.html
+++ b/socialapp/templates/socialapp/base.html
@@ -3,6 +3,7 @@
 <head>
     <title>Social Site</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    {% block extra_head %}{% endblock %}
 </head>
 <body class="p-3">
     <div class="container">


### PR DESCRIPTION
## Summary
- add `extra_head` block to `base.html`
- style login page with MySpace-inspired theme

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68409fd9e5548320b7d04ed823cbbbf7