### PR TITLE
Add default user and blue-green style

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Due to environment limitations, required packages like Django may not be install
 
 ```bash
 python manage.py migrate
-python manage.py createsuperuser
 ```
+
+A default user with username `demo` and password `demo123` is created
+automatically after running migrations.
 
 Start the development server:
 

--- a/socialapp/apps.py
+++ b/socialapp/apps.py
@@ -1,6 +1,17 @@
 from django.apps import AppConfig
+from django.db.models.signals import post_migrate
+from django.contrib.auth import get_user_model
 
 
 class SocialappConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'socialapp'
+
+    def ready(self):
+        User = get_user_model()
+
+        def create_default_user(sender, **kwargs):
+            if not User.objects.filter(username='demo').exists():
+                User.objects.create_user('demo', password='demo123')
+
+        post_migrate.connect(create_default_user, sender=self)

--- a/socialapp/templates/registration/login.html
+++ b/socialapp/templates/registration/login.html
@@ -2,13 +2,6 @@
 
 {% block extra_head %}
 <style>
-    body {
-        background: linear-gradient(#004080, #002050);
-        font-family: "Trebuchet MS", Arial, sans-serif;
-        color: #fff;
-        min-height: 100vh;
-    }
-
     .myspace-login-box {
         background: #fff;
         color: #000;

--- a/socialapp/templates/socialapp/base.html
+++ b/socialapp/templates/socialapp/base.html
@@ -3,6 +3,16 @@
 <head>
     <title>Social Site</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body {
+            background: linear-gradient(to bottom, #0099ff, #00cc66);
+            color: #fff;
+            min-height: 100vh;
+        }
+        h1 {
+            color: #fff;
+        }
+    </style>
     {% block extra_head %}{% endblock %}
 </head>
 <body class="p-3">

--- a/socialapp/templates/socialapp/home.html
+++ b/socialapp/templates/socialapp/home.html
@@ -5,7 +5,7 @@
 <form method="post">
     {% csrf_token %}
     {{ form.as_p }}
-    <button type="submit">Share</button>
+    <button type="submit" class="btn btn-success">Share</button>
 </form>
 <ul>
     {% for post in posts %}


### PR DESCRIPTION
## Summary
- create a demo user automatically after migrations
- apply blue/green gradient background
- tweak login box styling and add Bootstrap button
- update README with login info

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6840bd79b6d88320a1607083b4b68e76