### PR TITLE
Add registration page

### DIFF
--- a/socialapp/forms.py
+++ b/socialapp/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
 from .models import Post
 
 class PostForm(forms.ModelForm):
@@ -15,3 +15,15 @@ class BootstrapAuthenticationForm(AuthenticationForm):
         super().__init__(*args, **kwargs)
         for visible in self.visible_fields():
             visible.field.widget.attrs['class'] = 'form-control'
+
+
+class BootstrapUserCreationForm(UserCreationForm):
+    """User creation form with Bootstrap styling."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for visible in self.visible_fields():
+            visible.field.widget.attrs['class'] = 'form-control'
+
+    class Meta(UserCreationForm.Meta):
+        fields = UserCreationForm.Meta.fields

--- a/socialapp/templates/registration/register.html
+++ b/socialapp/templates/registration/register.html
@@ -1,0 +1,42 @@
+{% extends 'socialapp/base.html' %}
+
+{% block extra_head %}
+<style>
+    body {
+        background: linear-gradient(#004080, #002050);
+        font-family: "Trebuchet MS", Arial, sans-serif;
+        color: #fff;
+        min-height: 100vh;
+    }
+
+    .myspace-login-box {
+        background: #fff;
+        color: #000;
+        padding: 20px;
+        border-radius: 10px;
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+        margin-top: 60px;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-4 myspace-login-box">
+    <h2 class="mb-3">Register</h2>
+    <form method="post">
+      {% csrf_token %}
+      {% for field in form %}
+        <div class="mb-3">
+          {{ field.label_tag }}
+          {{ field }}
+          {% if field.errors %}
+            <div class="text-danger small">{{ field.errors|striptags }}</div>
+          {% endif %}
+        </div>
+      {% endfor %}
+      <button type="submit" class="btn btn-primary w-100">Register</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/socialapp/templates/socialapp/base.html
+++ b/socialapp/templates/socialapp/base.html
@@ -15,7 +15,10 @@
             | <a href="{% url 'landing' %}">InsightMint</a>
         </p>
     {% else %}
-        <p><a href="{% url 'login' %}">Login</a></p>
+        <p>
+            <a href="{% url 'login' %}">Login</a> |
+            <a href="{% url 'register' %}">Register</a>
+        </p>
     {% endif %}
     <hr>
     {% block content %}{% endblock %}

--- a/socialapp/views.py
+++ b/socialapp/views.py
@@ -1,8 +1,9 @@
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
+from django.contrib.auth import login
 from django.shortcuts import get_object_or_404, render, redirect
 
-from .forms import PostForm
+from .forms import PostForm, BootstrapUserCreationForm
 from .models import Profile, Post
 
 @login_required
@@ -25,3 +26,16 @@ def profile_detail(request, username):
     user = get_object_or_404(User, username=username)
     profile, _ = Profile.objects.get_or_create(user=user)
     return render(request, 'socialapp/profile_detail.html', {'profile': profile})
+
+
+def register(request):
+    """Simple user registration view."""
+    if request.method == 'POST':
+        form = BootstrapUserCreationForm(request.POST)
+        if form.is_valid():
+            user = form.save()
+            login(request, user)
+            return redirect('home')
+    else:
+        form = BootstrapUserCreationForm()
+    return render(request, 'registration/register.html', {'form': form})

--- a/socialsite/urls.py
+++ b/socialsite/urls.py
@@ -2,11 +2,13 @@ from django.contrib import admin
 from django.urls import path, include
 from django.contrib.auth import views as auth_views
 from socialapp.forms import BootstrapAuthenticationForm
+from socialapp import views as social_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('socialapp.urls')),
     path('insightmint/', include('insightmint.urls')),
     path('accounts/login/', auth_views.LoginView.as_view(authentication_form=BootstrapAuthenticationForm), name='login'),
+    path('accounts/register/', social_views.register, name='register'),
     path('accounts/', include('django.contrib.auth.urls')),
 ]


### PR DESCRIPTION
## Summary
- let users register with a Bootstrap styled form
- include register link in site base template
- wire up register view in URLs

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6840c0a43f30832096d10acd1674d267